### PR TITLE
Check for duplicated option values and avoid adding them

### DIFF
--- a/lib/solidus_importer/processors/option_values.rb
+++ b/lib/solidus_importer/processors/option_values.rb
@@ -25,7 +25,7 @@ module SolidusImporter
           )
           option_value.presentation = name
           option_value.save!
-          variant.option_values << option_value
+          variant.option_values << option_value unless variant.option_values.include?(option_value)
           variant.save!
         end
       end

--- a/spec/lib/solidus_importer/processors/option_values_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_values_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SolidusImporter::Processors::OptionValues do
     let(:variant) { create :base_variant }
     let(:product) { variant.product }
     let(:color) { create :option_type, presentation: 'Color' }
-    let(:size) { create :option_type, presentation: 'Size' }
+    let(:size) { create :option_type, presentation: 'Size', name: 'size' }
     let(:data) do
       {
         'Option1 Name' => 'Size',
@@ -49,6 +49,20 @@ RSpec.describe SolidusImporter::Processors::OptionValues do
       end
 
       it 'does not create option values for variant in row' do
+        expect { described_method }.not_to change(variant.option_values, :count)
+      end
+    end
+
+    context 'when an Option is imported a second time for the same variant' do
+      let(:data) do
+        {
+          'Option1 Name' => 'Size',
+          'Option1 Value' => '3XL'
+        }
+      end
+
+      it 'is not added' do
+        variant.set_option_value('size', '3xl')
         expect { described_method }.not_to change(variant.option_values, :count)
       end
     end


### PR DESCRIPTION
When the import file has more lines for each variant in order to
specify more images per variant the mapping to the variant is made
through options instead of variant sku (which is optional). As a
result of repeating the options on all lines they are also added
by the importer multiple times ending. This change avoids adding
them if already present.