### PR TITLE
Allow Ruby version 2.5 and up

### DIFF
--- a/solidus_importer.gemspec
+++ b/solidus_importer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_importer'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_importer/releases'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
The current version is restricted to 2.5 but does support Solidus 3. This way the ruby version is in line with the Solidus 3.0 core gem.